### PR TITLE
add wishlist command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+Bandcamper

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,9 +15,10 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-func init(){
+func init() {
 	rootCmd.AddCommand(bandCmd)
 	rootCmd.AddCommand(urlCmd)
+	rootCmd.AddCommand(wishlistCmd)
 }
 
 func Execute() {
@@ -25,4 +26,3 @@ func Execute() {
 		log.Fatalln(err)
 	}
 }
-

--- a/cmd/wishlist.go
+++ b/cmd/wishlist.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/AssassinRobot/Bandcamper/downloader"
+	"github.com/AssassinRobot/Bandcamper/pkg/scrap"
+	"github.com/AssassinRobot/Bandcamper/utils"
+	"github.com/spf13/cobra"
+	"log"
+)
+
+var (
+	wishlistDownloader downloader.WishlistDownloader
+)
+
+func init() {
+	urlFile := utils.NewFileMngmnt()
+	urlHttp := utils.NewHttpMngmnt()
+
+	scrapper := scrap.NewScrapper()
+
+	wishlistDownloader = downloader.NewWishlistDownloader(urlHttp, urlFile, scrapper)
+}
+
+var wishlistCmd = &cobra.Command{
+	Use:   "wishlist",
+	Short: "Download wishlist albums",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		username := args[0]
+
+		err := wishlistDownloader.Download(username)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		log.Println("Done")
+	},
+}

--- a/cmd/wishlist.go
+++ b/cmd/wishlist.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/AssassinRobot/Bandcamper/downloader"
 	"github.com/AssassinRobot/Bandcamper/pkg/scrap"
 	"github.com/AssassinRobot/Bandcamper/utils"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 var (
@@ -29,7 +31,15 @@ var wishlistCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		username := args[0]
 
-		err := wishlistDownloader.Download(username)
+		var cookies string
+		if cookieEnv := os.Getenv("BANDCAMP_COOKIES"); cookieEnv != "" {
+			cookies = cookieEnv
+		} else {
+			fmt.Println("Please set the BANDCAMP_COOKIES environment variable with your Bandcamp cookies.")
+			return
+		}
+
+		err := wishlistDownloader.Download(username, cookies)
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/downloader/band_downloader.go
+++ b/downloader/band_downloader.go
@@ -20,7 +20,7 @@ type bandDownloader struct {
 func (c *bandDownloader) GetBand(name string) (*entities.Band, error) {
 	url := fmt.Sprintf("https://%s.bandcamp.com/music", helpers.GetValidName(name))
 
-	res, getURLError := c.http.Get(url)
+	res, getURLError := c.http.Get(url, nil)
 	if getURLError != nil {
 		return nil, getURLError
 	}
@@ -41,7 +41,7 @@ func (c *bandDownloader) GetBand(name string) (*entities.Band, error) {
 }
 
 func (c *bandDownloader) GetAlbum(albumURL string) (*entities.TrackData, error) {
-	res, getURLError := c.http.Get(albumURL)
+	res, getURLError := c.http.Get(albumURL, nil)
 	if getURLError != nil {
 		return nil, getURLError
 	}
@@ -62,7 +62,7 @@ func (c *bandDownloader) GetAlbum(albumURL string) (*entities.TrackData, error) 
 	return data, nil
 }
 func (c *bandDownloader) GetTrack(trackURL string) (*entities.TrackData, error) {
-	res, getURLError := c.http.Get(trackURL)
+	res, getURLError := c.http.Get(trackURL, nil)
 	if getURLError != nil {
 		return nil, getURLError
 	}
@@ -79,14 +79,14 @@ func (c *bandDownloader) GetTrack(trackURL string) (*entities.TrackData, error) 
 		return nil, scrapError
 	}
 	data.BasePath = helpers.GetBasePath(trackURL)
-	log.Println(data.BasePath )
+	log.Println(data.BasePath)
 
 	return data, nil
 }
 
 func (c *bandDownloader) DownloadAlbum(albumURL string) error {
 	err := c.URLDownloader.Download(albumURL)
-	if err != nil{
+	if err != nil {
 		return err
 	}
 	return nil
@@ -94,17 +94,17 @@ func (c *bandDownloader) DownloadAlbum(albumURL string) error {
 
 func (c *bandDownloader) DownloadTrack(trackURL string) error {
 	err := c.URLDownloader.Download(trackURL)
-	if err != nil{
+	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func NewBandDownloader(http *utils.HttpMngmnt, file *utils.FileMngmnt, bandScrapper scrap.BandScrapper,downloader URLDownloader) BandDownloader {
+func NewBandDownloader(http *utils.HttpMngmnt, file *utils.FileMngmnt, bandScrapper scrap.BandScrapper, downloader URLDownloader) BandDownloader {
 	return &bandDownloader{
-		http:         http,
-		file:         file,
-		bandScrapper: bandScrapper,
+		http:          http,
+		file:          file,
+		bandScrapper:  bandScrapper,
 		URLDownloader: downloader,
 	}
 }

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -16,5 +16,5 @@ type URLDownloader interface {
 }
 
 type WishlistDownloader interface {
-	Download(username string) error
+	Download(username string, cookies string) error
 }

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -12,6 +12,7 @@ type BandDownloader interface {
 
 type URLDownloader interface {
 	Download(url string) error
+	DownloadAll(urls []string) error
 }
 
 type WishlistDownloader interface {

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -13,3 +13,7 @@ type BandDownloader interface {
 type URLDownloader interface {
 	Download(url string) error
 }
+
+type WishlistDownloader interface {
+	Download(username string) error
+}

--- a/downloader/url_downloader.go
+++ b/downloader/url_downloader.go
@@ -24,7 +24,7 @@ var wg = &sync.WaitGroup{}
 func (c *urlDownloader) Download(url string) error {
 	var errorChan = make(chan error, 500)
 
-	res, getURLError := c.http.Get(url)
+	res, getURLError := c.http.Get(url, nil)
 	if getURLError != nil {
 		return getURLError
 	}
@@ -52,7 +52,7 @@ func (c *urlDownloader) Download(url string) error {
 		return createError
 	}
 
-	imageRes, getImageError := c.http.Get(trackData.ArtworkURL)
+	imageRes, getImageError := c.http.Get(trackData.ArtworkURL, nil)
 	if getImageError != nil {
 		return getImageError
 	}
@@ -88,7 +88,7 @@ func (c *urlDownloader) Download(url string) error {
 
 			c.downloads = append(c.downloads, fmt.Sprintf("%s - %s", mp3.Artist, mp3.CurrentTrackTitle))
 
-			mp3Res, mp3DownloadError := c.http.Get(mp3.CurrentTrackURL)
+			mp3Res, mp3DownloadError := c.http.Get(mp3.CurrentTrackURL, nil)
 			if mp3DownloadError != nil {
 				errorChan <- mp3DownloadError
 				return

--- a/downloader/url_downloader.go
+++ b/downloader/url_downloader.go
@@ -124,6 +124,41 @@ func (c *urlDownloader) Download(url string) error {
 	return <-errorChan
 }
 
+func (c *urlDownloader) DownloadAll(urls []string) error {
+	var errorChan = make(chan error, len(urls))
+
+	// Add the number of tasks (URLs) to wait on
+	wg.Add(len(urls))
+
+	// Loop over URLs and create a goroutine for each URL
+	for _, url := range urls {
+		go func(url string) {
+			defer wg.Done()
+
+			// Call the Download function for each URL
+			err := c.Download(url)
+			if err != nil {
+				errorChan <- err
+			}
+		}(url)
+	}
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	// Close the error channel and return the first error encountered
+	close(errorChan)
+
+	// Return the first error from the channel (if any)
+	for err := range errorChan {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func NewURLDownloader(http *utils.HttpMngmnt, file *utils.FileMngmnt, scrapper scrap.Scrapper) URLDownloader {
 	return &urlDownloader{
 		http:     http,

--- a/downloader/wishlist_downloader.go
+++ b/downloader/wishlist_downloader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+
 	// "strconv"
 	//
 	// "github.com/AssassinRobot/Bandcamper/entities"
@@ -27,7 +28,8 @@ func (c *wishlistDownloader) Download(username string) error {
 	var wishlistUrl = fmt.Sprintf("https://bandcamp.com/%s/wishlist", username)
 
 	// TODO: get cookies from Chrome or Firefox
-	var cookies = os.Getenv("BANCAMP_COOKIES")
+	var cookies = os.Getenv("BANDCAMP_COOKIES")
+	println("Using cookies:", cookies)
 	var headers = map[string]string{
 		"Cookie":     cookies,
 		"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
@@ -49,10 +51,20 @@ func (c *wishlistDownloader) Download(username string) error {
 	// Just print the response body for debugging
 	println("Response Status:", res.Status)
 
-	// trackData, scrapError := c.scrapper.ListInfos(res.Body)
-	// if scrapError != nil {
-	// 	return scrapError
-	// }
+	wishlistData, scrapError := c.scrapper.ListWishlist(res.Body)
+	if scrapError != nil {
+		return scrapError
+	}
+
+	// just print wishlist and return
+	for _, item := range wishlistData {
+		fmt.Printf("Wishlist Item: %s", item.Title)
+		fmt.Printf("Album URL: %s\n", item.AlbumURL)
+		fmt.Printf("Artwork URL: %s\n", item.ImageURL)
+		fmt.Println()
+	}
+	return nil
+
 	//
 	// ticker := helpers.DownloadStatus(&c.downloads)
 	//

--- a/downloader/wishlist_downloader.go
+++ b/downloader/wishlist_downloader.go
@@ -1,0 +1,132 @@
+package downloader
+
+import (
+	"fmt"
+	"github.com/AssassinRobot/Bandcamper/entities"
+	"github.com/AssassinRobot/Bandcamper/helpers"
+	"github.com/AssassinRobot/Bandcamper/pkg/scrap"
+	"github.com/AssassinRobot/Bandcamper/utils"
+	"log"
+	"strconv"
+)
+
+type wishlistDownloader struct {
+	http      *utils.HttpMngmnt
+	file      *utils.FileMngmnt
+	downloads []string
+	scrapper  scrap.Scrapper
+}
+
+// var wg = &sync.WaitGroup{}
+
+func (c *wishlistDownloader) Download(username string) error {
+	var errorChan = make(chan error, 500)
+
+	var wishlistUrl = fmt.Sprintf("https://bandcamp.com/%s/wishlist", username)
+	res, getURLError := c.http.Get(wishlistUrl)
+	if getURLError != nil {
+		return getURLError
+	}
+
+	defer func() {
+		err := res.Body.Close()
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	trackData, scrapError := c.scrapper.ListInfos(res.Body)
+	if scrapError != nil {
+		return scrapError
+	}
+
+	ticker := helpers.DownloadStatus(&c.downloads)
+
+	baseFilepath := fmt.Sprintf("./%s%s", helpers.RemoveAlphaNum(trackData.Artist), helpers.RemoveAlphaNum(trackData.Current.Title))
+
+	trackData.AlbumArtworkFilepath = fmt.Sprintf("%s/%s.jpg", baseFilepath, trackData.Current.Title)
+
+	createError := c.file.CreateDir(baseFilepath)
+	if createError != nil {
+		return createError
+	}
+
+	imageRes, getImageError := c.http.Get(trackData.ArtworkURL)
+	if getImageError != nil {
+		return getImageError
+	}
+
+	defer func() {
+		err := res.Body.Close()
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	saveImageError := c.file.Save(trackData.AlbumArtworkFilepath, imageRes.Body)
+	if saveImageError != nil {
+		return saveImageError
+	}
+
+	for _, v := range trackData.TrackInfo {
+		wg.Add(1)
+
+		currentTrackData := *trackData
+
+		currentTrackData.CurrentTrackNum = strconv.Itoa(v.TrackNum)
+		currentTrackData.CurrentTrackTitle = v.Title
+		currentTrackData.CurrentTrackURL = v.File.Mp3128
+		currentTrackData.CurrentTrackFilepath = baseFilepath +
+			"/" + helpers.RemoveAlphaNum(currentTrackData.CurrentTrackNum) +
+			"-" + helpers.RemoveAlphaNum(currentTrackData.Artist) +
+			"-" + helpers.RemoveAlphaNum(currentTrackData.CurrentTrackTitle) +
+			".mp3"
+
+		go func(mp3 entities.TrackData) {
+			defer wg.Done()
+
+			c.downloads = append(c.downloads, fmt.Sprintf("%s - %s", mp3.Artist, mp3.CurrentTrackTitle))
+
+			mp3Res, mp3DownloadError := c.http.Get(mp3.CurrentTrackURL)
+			if mp3DownloadError != nil {
+				errorChan <- mp3DownloadError
+				return
+			}
+
+			defer func() {
+				err := mp3Res.Body.Close()
+				if err != nil {
+					log.Fatalln(err)
+				}
+			}()
+
+			saveError := c.file.Save(mp3.CurrentTrackFilepath, mp3Res.Body)
+			if saveError != nil {
+				errorChan <- saveError
+				return
+			}
+
+			tagFileError := c.file.TagFile(&mp3)
+			if tagFileError != nil {
+				errorChan <- tagFileError
+				return
+			}
+		}(currentTrackData)
+	}
+
+	wg.Wait()
+
+	ticker.Stop()
+
+	close(errorChan)
+
+	return <-errorChan
+}
+
+func NewWishlistDownloader(http *utils.HttpMngmnt, file *utils.FileMngmnt, scrapper scrap.Scrapper) WishlistDownloader {
+	return &wishlistDownloader{
+		http:     http,
+		file:     file,
+		scrapper: scrapper,
+	}
+}

--- a/downloader/wishlist_downloader.go
+++ b/downloader/wishlist_downloader.go
@@ -3,7 +3,6 @@ package downloader
 import (
 	"fmt"
 	"log"
-	"os"
 
 	// "strconv"
 	//
@@ -22,16 +21,13 @@ type wishlistDownloader struct {
 
 // var wg = &sync.WaitGroup{}
 
-func (c *wishlistDownloader) Download(username string) error {
+func (c *wishlistDownloader) Download(username string, cookies string) error {
 	var errorChan = make(chan error, 500)
 
 	var url = fmt.Sprintf("https://bandcamp.com/%s/wishlist", username)
-	var cookies = os.Getenv("BANDCAMP_COOKIES")
 	var headers = map[string]string{
-		"Cookie":     cookies,
-		"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+		"Cookie": cookies,
 	}
-
 	res, getURLError := c.http.Get(url, headers)
 
 	if getURLError != nil {

--- a/downloader/wishlist_downloader.go
+++ b/downloader/wishlist_downloader.go
@@ -2,12 +2,14 @@ package downloader
 
 import (
 	"fmt"
-	"github.com/AssassinRobot/Bandcamper/entities"
-	"github.com/AssassinRobot/Bandcamper/helpers"
+	"log"
+	"os"
+	// "strconv"
+	//
+	// "github.com/AssassinRobot/Bandcamper/entities"
+	// "github.com/AssassinRobot/Bandcamper/helpers"
 	"github.com/AssassinRobot/Bandcamper/pkg/scrap"
 	"github.com/AssassinRobot/Bandcamper/utils"
-	"log"
-	"strconv"
 )
 
 type wishlistDownloader struct {
@@ -23,7 +25,16 @@ func (c *wishlistDownloader) Download(username string) error {
 	var errorChan = make(chan error, 500)
 
 	var wishlistUrl = fmt.Sprintf("https://bandcamp.com/%s/wishlist", username)
-	res, getURLError := c.http.Get(wishlistUrl)
+
+	// TODO: get cookies from Chrome or Firefox
+	var cookies = os.Getenv("BANCAMP_COOKIES")
+	var headers = map[string]string{
+		"Cookie":     cookies,
+		"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+	}
+
+	res, getURLError := c.http.Get(wishlistUrl, headers)
+
 	if getURLError != nil {
 		return getURLError
 	}
@@ -35,88 +46,91 @@ func (c *wishlistDownloader) Download(username string) error {
 		}
 	}()
 
-	trackData, scrapError := c.scrapper.ListInfos(res.Body)
-	if scrapError != nil {
-		return scrapError
-	}
+	// Just print the response body for debugging
+	println("Response Status:", res.Status)
 
-	ticker := helpers.DownloadStatus(&c.downloads)
-
-	baseFilepath := fmt.Sprintf("./%s%s", helpers.RemoveAlphaNum(trackData.Artist), helpers.RemoveAlphaNum(trackData.Current.Title))
-
-	trackData.AlbumArtworkFilepath = fmt.Sprintf("%s/%s.jpg", baseFilepath, trackData.Current.Title)
-
-	createError := c.file.CreateDir(baseFilepath)
-	if createError != nil {
-		return createError
-	}
-
-	imageRes, getImageError := c.http.Get(trackData.ArtworkURL)
-	if getImageError != nil {
-		return getImageError
-	}
-
-	defer func() {
-		err := res.Body.Close()
-		if err != nil {
-			log.Fatalln(err)
-		}
-	}()
-
-	saveImageError := c.file.Save(trackData.AlbumArtworkFilepath, imageRes.Body)
-	if saveImageError != nil {
-		return saveImageError
-	}
-
-	for _, v := range trackData.TrackInfo {
-		wg.Add(1)
-
-		currentTrackData := *trackData
-
-		currentTrackData.CurrentTrackNum = strconv.Itoa(v.TrackNum)
-		currentTrackData.CurrentTrackTitle = v.Title
-		currentTrackData.CurrentTrackURL = v.File.Mp3128
-		currentTrackData.CurrentTrackFilepath = baseFilepath +
-			"/" + helpers.RemoveAlphaNum(currentTrackData.CurrentTrackNum) +
-			"-" + helpers.RemoveAlphaNum(currentTrackData.Artist) +
-			"-" + helpers.RemoveAlphaNum(currentTrackData.CurrentTrackTitle) +
-			".mp3"
-
-		go func(mp3 entities.TrackData) {
-			defer wg.Done()
-
-			c.downloads = append(c.downloads, fmt.Sprintf("%s - %s", mp3.Artist, mp3.CurrentTrackTitle))
-
-			mp3Res, mp3DownloadError := c.http.Get(mp3.CurrentTrackURL)
-			if mp3DownloadError != nil {
-				errorChan <- mp3DownloadError
-				return
-			}
-
-			defer func() {
-				err := mp3Res.Body.Close()
-				if err != nil {
-					log.Fatalln(err)
-				}
-			}()
-
-			saveError := c.file.Save(mp3.CurrentTrackFilepath, mp3Res.Body)
-			if saveError != nil {
-				errorChan <- saveError
-				return
-			}
-
-			tagFileError := c.file.TagFile(&mp3)
-			if tagFileError != nil {
-				errorChan <- tagFileError
-				return
-			}
-		}(currentTrackData)
-	}
-
+	// trackData, scrapError := c.scrapper.ListInfos(res.Body)
+	// if scrapError != nil {
+	// 	return scrapError
+	// }
+	//
+	// ticker := helpers.DownloadStatus(&c.downloads)
+	//
+	// baseFilepath := fmt.Sprintf("./%s%s", helpers.RemoveAlphaNum(trackData.Artist), helpers.RemoveAlphaNum(trackData.Current.Title))
+	//
+	// trackData.AlbumArtworkFilepath = fmt.Sprintf("%s/%s.jpg", baseFilepath, trackData.Current.Title)
+	//
+	// createError := c.file.CreateDir(baseFilepath)
+	// if createError != nil {
+	// 	return createError
+	// }
+	//
+	// imageRes, getImageError := c.http.Get(trackData.ArtworkURL)
+	// if getImageError != nil {
+	// 	return getImageError
+	// }
+	//
+	// defer func() {
+	// 	err := res.Body.Close()
+	// 	if err != nil {
+	// 		log.Fatalln(err)
+	// 	}
+	// }()
+	//
+	// saveImageError := c.file.Save(trackData.AlbumArtworkFilepath, imageRes.Body)
+	// if saveImageError != nil {
+	// 	return saveImageError
+	// }
+	//
+	// for _, v := range trackData.TrackInfo {
+	// 	wg.Add(1)
+	//
+	// 	currentTrackData := *trackData
+	//
+	// 	currentTrackData.CurrentTrackNum = strconv.Itoa(v.TrackNum)
+	// 	currentTrackData.CurrentTrackTitle = v.Title
+	// 	currentTrackData.CurrentTrackURL = v.File.Mp3128
+	// 	currentTrackData.CurrentTrackFilepath = baseFilepath +
+	// 		"/" + helpers.RemoveAlphaNum(currentTrackData.CurrentTrackNum) +
+	// 		"-" + helpers.RemoveAlphaNum(currentTrackData.Artist) +
+	// 		"-" + helpers.RemoveAlphaNum(currentTrackData.CurrentTrackTitle) +
+	// 		".mp3"
+	//
+	// 	go func(mp3 entities.TrackData) {
+	// 		defer wg.Done()
+	//
+	// 		c.downloads = append(c.downloads, fmt.Sprintf("%s - %s", mp3.Artist, mp3.CurrentTrackTitle))
+	//
+	// 		mp3Res, mp3DownloadError := c.http.Get(mp3.CurrentTrackURL)
+	// 		if mp3DownloadError != nil {
+	// 			errorChan <- mp3DownloadError
+	// 			return
+	// 		}
+	//
+	// 		defer func() {
+	// 			err := mp3Res.Body.Close()
+	// 			if err != nil {
+	// 				log.Fatalln(err)
+	// 			}
+	// 		}()
+	//
+	// 		saveError := c.file.Save(mp3.CurrentTrackFilepath, mp3Res.Body)
+	// 		if saveError != nil {
+	// 			errorChan <- saveError
+	// 			return
+	// 		}
+	//
+	// 		tagFileError := c.file.TagFile(&mp3)
+	// 		if tagFileError != nil {
+	// 			errorChan <- tagFileError
+	// 			return
+	// 		}
+	// 	}(currentTrackData)
+	// }
+	//
 	wg.Wait()
 
-	ticker.Stop()
+	// ticker.Stop()
 
 	close(errorChan)
 

--- a/downloader/wishlist_downloader.go
+++ b/downloader/wishlist_downloader.go
@@ -56,96 +56,15 @@ func (c *wishlistDownloader) Download(username string) error {
 		return scrapError
 	}
 
+	urlDownloader := NewURLDownloader(c.http, c.file, c.scrapper)
+
 	// just print wishlist and return
 	for _, item := range wishlistData {
 		fmt.Printf("Wishlist Item: %s", item.Title)
-		fmt.Printf("Album URL: %s\n", item.AlbumURL)
-		fmt.Printf("Artwork URL: %s\n", item.ImageURL)
-		fmt.Println()
+		urlDownloader.Download(item.AlbumURL)
 	}
-	return nil
-
-	//
-	// ticker := helpers.DownloadStatus(&c.downloads)
-	//
-	// baseFilepath := fmt.Sprintf("./%s%s", helpers.RemoveAlphaNum(trackData.Artist), helpers.RemoveAlphaNum(trackData.Current.Title))
-	//
-	// trackData.AlbumArtworkFilepath = fmt.Sprintf("%s/%s.jpg", baseFilepath, trackData.Current.Title)
-	//
-	// createError := c.file.CreateDir(baseFilepath)
-	// if createError != nil {
-	// 	return createError
-	// }
-	//
-	// imageRes, getImageError := c.http.Get(trackData.ArtworkURL)
-	// if getImageError != nil {
-	// 	return getImageError
-	// }
-	//
-	// defer func() {
-	// 	err := res.Body.Close()
-	// 	if err != nil {
-	// 		log.Fatalln(err)
-	// 	}
-	// }()
-	//
-	// saveImageError := c.file.Save(trackData.AlbumArtworkFilepath, imageRes.Body)
-	// if saveImageError != nil {
-	// 	return saveImageError
-	// }
-	//
-	// for _, v := range trackData.TrackInfo {
-	// 	wg.Add(1)
-	//
-	// 	currentTrackData := *trackData
-	//
-	// 	currentTrackData.CurrentTrackNum = strconv.Itoa(v.TrackNum)
-	// 	currentTrackData.CurrentTrackTitle = v.Title
-	// 	currentTrackData.CurrentTrackURL = v.File.Mp3128
-	// 	currentTrackData.CurrentTrackFilepath = baseFilepath +
-	// 		"/" + helpers.RemoveAlphaNum(currentTrackData.CurrentTrackNum) +
-	// 		"-" + helpers.RemoveAlphaNum(currentTrackData.Artist) +
-	// 		"-" + helpers.RemoveAlphaNum(currentTrackData.CurrentTrackTitle) +
-	// 		".mp3"
-	//
-	// 	go func(mp3 entities.TrackData) {
-	// 		defer wg.Done()
-	//
-	// 		c.downloads = append(c.downloads, fmt.Sprintf("%s - %s", mp3.Artist, mp3.CurrentTrackTitle))
-	//
-	// 		mp3Res, mp3DownloadError := c.http.Get(mp3.CurrentTrackURL)
-	// 		if mp3DownloadError != nil {
-	// 			errorChan <- mp3DownloadError
-	// 			return
-	// 		}
-	//
-	// 		defer func() {
-	// 			err := mp3Res.Body.Close()
-	// 			if err != nil {
-	// 				log.Fatalln(err)
-	// 			}
-	// 		}()
-	//
-	// 		saveError := c.file.Save(mp3.CurrentTrackFilepath, mp3Res.Body)
-	// 		if saveError != nil {
-	// 			errorChan <- saveError
-	// 			return
-	// 		}
-	//
-	// 		tagFileError := c.file.TagFile(&mp3)
-	// 		if tagFileError != nil {
-	// 			errorChan <- tagFileError
-	// 			return
-	// 		}
-	// 	}(currentTrackData)
-	// }
-	//
-	wg.Wait()
-
-	// ticker.Stop()
 
 	close(errorChan)
-
 	return <-errorChan
 }
 

--- a/downloader/wishlist_downloader.go
+++ b/downloader/wishlist_downloader.go
@@ -25,17 +25,14 @@ type wishlistDownloader struct {
 func (c *wishlistDownloader) Download(username string) error {
 	var errorChan = make(chan error, 500)
 
-	var wishlistUrl = fmt.Sprintf("https://bandcamp.com/%s/wishlist", username)
-
-	// TODO: get cookies from Chrome or Firefox
+	var url = fmt.Sprintf("https://bandcamp.com/%s/wishlist", username)
 	var cookies = os.Getenv("BANDCAMP_COOKIES")
-	println("Using cookies:", cookies)
 	var headers = map[string]string{
 		"Cookie":     cookies,
 		"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
 	}
 
-	res, getURLError := c.http.Get(wishlistUrl, headers)
+	res, getURLError := c.http.Get(url, headers)
 
 	if getURLError != nil {
 		return getURLError
@@ -56,12 +53,19 @@ func (c *wishlistDownloader) Download(username string) error {
 		return scrapError
 	}
 
-	urlDownloader := NewURLDownloader(c.http, c.file, c.scrapper)
-
 	// just print wishlist and return
+	var album_urls []string
 	for _, item := range wishlistData {
 		fmt.Printf("Wishlist Item: %s", item.Title)
-		urlDownloader.Download(item.AlbumURL)
+		if item.AlbumURL != "" {
+			album_urls = append(album_urls, item.AlbumURL)
+		}
+	}
+
+	urlDownloader := NewURLDownloader(c.http, c.file, c.scrapper)
+	err := urlDownloader.DownloadAll(album_urls)
+	if err != nil {
+		log.Fatalf("Error occurred: %v", err)
 	}
 
 	close(errorChan)

--- a/pkg/scrap/scrapper.go
+++ b/pkg/scrap/scrapper.go
@@ -12,6 +12,7 @@ import (
 
 type Scrapper interface {
 	ListInfos(reader io.Reader) (*entities.TrackData, error)
+	ListWishlist(reader io.Reader) ([]*entities.Album, error)
 }
 
 func NewScrapper() Scrapper {
@@ -52,9 +53,34 @@ func (s *dataScrapper) ListInfos(reader io.Reader) (*entities.TrackData, error) 
 	case "album":
 		artwork = fmt.Sprintf("https://f4.bcbits.com/img/a%d_16.jpg", trackData.Current.ArtID)
 	default:
-		return nil,fmt.Errorf("error get image:%d", trackData.Current.ID)
+		return nil, fmt.Errorf("error get image:%d", trackData.Current.ID)
 	}
 	trackData.ArtworkURL = artwork
 
 	return trackData, nil
+}
+
+func (s *dataScrapper) ListWishlist(reader io.Reader) ([]*entities.Album, error) {
+	var listWishlistError error
+
+	doc, newDocError := goquery.NewDocumentFromReader(reader)
+	if newDocError != nil {
+		listWishlistError = newDocError
+	}
+
+	var albums []*entities.Album
+
+	doc.Find(".collection-item-container").Each(func(i int, s *goquery.Selection) {
+		var album = &entities.Album{}
+		album.Title = s.Find(".collection-item-title").Text()
+		album.AlbumURL = s.Find(".item-link").AttrOr("href", "")
+		album.ImageURL = s.Find(".collection-item-art").AttrOr("src", "")
+		albums = append(albums, album)
+	})
+
+	if listWishlistError != nil {
+		return nil, listWishlistError
+	}
+
+	return albums, nil
 }

--- a/utils/http.go
+++ b/utils/http.go
@@ -17,12 +17,16 @@ func NewHttpMngmnt() *HttpMngmnt {
 	}
 }
 
-func (h *HttpMngmnt) Get(url string) (*http.Response, error) {
+func (h *HttpMngmnt) Get(url string, headers map[string]string) (*http.Response, error) {
 	log.Println("Getting... ", url)
 
 	req, httpRequestError := http.NewRequestWithContext(context.TODO(), "GET", url, nil)
 	if httpRequestError != nil {
 		return nil, httpRequestError
+	}
+
+	for key, value := range headers {
+		req.Header.Add(key, value)
 	}
 
 	res, httpGetError := h.client.Do(req)


### PR DESCRIPTION
This PR introduces a new command to download your bandcamp wishlist

```bash
 export BANDCAMP_COOKIES="client_id=123; session_id=123;"
./Bandcamper wishlist <username>
```

The command will scrape releases in your wishlist page and call `UrlDownloader.DownloadAll(urls []string)` to download the tracks

